### PR TITLE
Socket.receive_message/1: return {:error, reason} instead of crashing

### DIFF
--- a/lib/cantastic/socket.ex
+++ b/lib/cantastic/socket.ex
@@ -100,9 +100,10 @@ defmodule Cantastic.Socket do
   end
 
   @doc """
-  Receive one `message` frame on the `socket`. This function will block indefinitely until a message is received.
+  Receive one `message` frame on the `socket`. This function will block until a message
+  is received or the underlying socket reports an error (timeout, closed, etc.).
 
-  Returns: `{:ok, %Cantastic.SocketMessage{} = message}`
+  Returns: `{:ok, %Cantastic.SocketMessage{} = message}` or `{:error, reason}`.
 
   ## Examples
 
@@ -110,20 +111,25 @@ defmodule Cantastic.Socket do
       {:ok, %Cantastic.SocketMessage{} = message}
   """
   def receive_message(socket) do
-    [raw, timestamp_seconds, timestamp_usec] = case :socket.recvmsg(socket) do
+    case :socket.recvmsg(socket) do
       {:ok, %{
         iov: [raw],
         ctrl: [%{type: :timestamp, value: %{sec: timestamp_seconds, usec: timestamp_usec}}]
-      }} -> [raw, timestamp_seconds, timestamp_usec]
+      }} ->
+        build_message(raw, timestamp_seconds, timestamp_usec)
       {:ok, %{
         iov: [raw],
         ctrl: [_, %{type: :timestamp, value: %{sec: timestamp_seconds, usec: timestamp_usec}}]
-      }} -> [raw, timestamp_seconds, timestamp_usec]
+      }} ->
+        build_message(raw, timestamp_seconds, timestamp_usec)
+      {:error, reason} ->
+        {:error, reason}
     end
+  end
 
-    reception_timestamp = timestamp_seconds * 1_000_000 + timestamp_usec # TODO return timestamp
-    message = %SocketMessage{raw: raw, reception_timestamp: reception_timestamp}
-    {:ok, message}
+  defp build_message(raw, timestamp_seconds, timestamp_usec) do
+    reception_timestamp = timestamp_seconds * 1_000_000 + timestamp_usec
+    {:ok, %SocketMessage{raw: raw, reception_timestamp: reception_timestamp}}
   end
 
   defp bind(socket, interface, request_frame_id \\ 0, response_frame_id \\ 0) do


### PR DESCRIPTION
## Summary

`Cantastic.Socket.receive_message/1` crashes with `CaseClauseError` whenever `:socket.recvmsg/1` returns `{:error, _}` — its `case` only matches `{:ok, %{...}}` shapes. Any GenServer that called it (e.g. `Cantastic.OBD2.Request`) gets taken down along with it.

In practice this happens whenever an ISO-TP request needs a Flow Control frame from the responder and none arrives — e.g. running the OBD2 vehicle on a host `vcan0` with no peer, or on a real bus when the ECU goes silent. The kernel returns `{:error, :timeout}` and Cantastic explodes.

`OBD2.Request.handle_info(:send_request, _)` already has an `else {:error, error} -> …` branch in its `with`, designed to recover from this exact case — but `receive_message/1` never gave it the chance.

This change just adds the missing `{:error, reason} -> {:error, reason}` clause and updates the doc to reflect that the function can fail. No happy-path behaviour change.

## Test plan

- [ ] Existing espec suite still green.
- [ ] Boot the OVCS OBD2 vehicle on host vcan (`./ovcs run obd2`); the `live_data_slow` / `supported_pids` GenServers no longer terminate when no responder is on the bus — instead the `with` chain in `OBD2.Request` falls through to the error branch and the loop keeps trying.
- [ ] On real OBD2 hardware against a running ECU: live data, DTCs, vehicle info still decode end-to-end.